### PR TITLE
Fix Java11 Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,20 @@
-FROM alpine:3.8
+FROM alpine:latest
 
 
 # Default to UTF-8 file.encoding
 ENV LANG C.UTF-8
-
 # There might be newer builds, but not all are published (for apline) at: http://jdk.java.net/11/
 
 ENV JAVA_HOME="/jdk-11"
-ARG JDK_BUILD="28"
-ENV JDK_ARCHIVE="openjdk-11+${JDK_BUILD}_linux-x64-musl_bin.tar.gz"
 
-#RUN mkdir ${JAVA_HOME} && cd ${JAVA_HOME}
-
-RUN echo "Downloading ${JDK_ARCHIVE}"
-RUN wget https://download.java.net/java/early_access/alpine/${JDK_BUILD}/binaries/${JDK_ARCHIVE}
+RUN echo "Downloading jdk build"
+RUN wget http://drive.jku.at/ssf/s/readFile/share/8207/4867522971216226929/publicLink/openjdk-11-GA_linux-x64-musl_bin.tar.gz
 
 RUN echo "Downloading sha256 checksum"
-RUN wget https://download.java.net/java/early_access/alpine/${JDK_BUILD}/binaries/${JDK_ARCHIVE}.sha256
+RUN wget http://drive.jku.at/ssf/s/readFile/share/8208/-1932052387783488162/publicLink/openjdk-11-GA_linux-x64-musl_bin.tar.gz.sha256
 
+ENV JDK_ARCHIVE="openjdk-11-GA_linux-x64-musl_bin.tar.gz"
 RUN echo "Verify checksum"
-# Two spaces bewteen hash & filename, as the output of 'sha256sum openjdk-11-...tar.gz'
-RUN echo "  ${JDK_ARCHIVE}" >> ${JDK_ARCHIVE}.sha256
 RUN sha256sum -c ${JDK_ARCHIVE}.sha256
 
 RUN echo "Checksum is correct"
@@ -30,13 +24,11 @@ RUN echo "Extract JDK"
 RUN tar -xzf ${JDK_ARCHIVE}
 # Remove downlaoded files
 RUN rm ${JDK_ARCHIVE} ${JDK_ARCHIVE}.sha256 
-# Remove src.zip to reduce size
-RUN rm ${JAVA_HOME}/lib/src.zip
 
 ENV PATH=$PATH:${JAVA_HOME}/bin
 
-ENV JAVA_VERSION 11-ea+${JDK_BUILD}
-ENV JAVA_ALPINE_VERSION 11~${JDK_BUILD}-1
+ENV JAVA_VERSION 11-ea+28
+ENV JAVA_ALPINE_VERSION 11~28-1
 
 RUN echo $PATH
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Java and Alpine Linux
-The Alpine JDK port is an unsupported release, which is why there are only early access builds currently.
-However, the release candidate with build version 28 was unchanged for the GA Release, so you can consider it as the *General-Availability Release*.
+The Alpine JDK port is an unsupported release, which is why there were only early access builds.
+The Dockerfile in this repo uses the last of these builds, but they are no longer hosted by [java.net](https://jdk.java.net/11/):
+> The Alpine Linux build previously available on this page was removed as of JDK 11 GA. It’s not production-ready because it hasn’t been tested thoroughly enough to be considered a GA build.
+
+Consider using one of the [OpenJDK images](https://hub.docker.com/_/openjdk) instead (e.g. `12-jdk-alpine`).
+
 
 The JDK port for the Alpine Linux distribution, and in particular the musl C library, is part of the [Portola Project](http://openjdk.java.net/projects/portola).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Alpine JDK port is an unsupported release, which is why there were only earl
 The Dockerfile in this repo uses the last of these builds, but they are no longer hosted by [java.net](https://jdk.java.net/11/):
 > The Alpine Linux build previously available on this page was removed as of JDK 11 GA. It’s not production-ready because it hasn’t been tested thoroughly enough to be considered a GA build.
 
-Consider using one of the [OpenJDK images](https://hub.docker.com/_/openjdk) instead (e.g. `12-jdk-alpine`).
+Consider using one of the [OpenJDK images](https://hub.docker.com/_/openjdk) instead (e.g. `12-jdk-alpine`) or checkout the [Java12 branch](https://github.com/keckelt/openjdk11-alpine/tree/java12).
 
 
 The JDK port for the Alpine Linux distribution, and in particular the musl C library, is part of the [Portola Project](http://openjdk.java.net/projects/portola).

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   jar_container:
     build:
       context: https://github.com/keckelt/openjdk11-alpine.git
-      args:
-        JDK_BUILD: 28
     volumes:
       - './hello_world.jar:/Main.jar'
     command: java -jar /Main.jar


### PR DESCRIPTION
java.net no longer provides the alpine builds. 

See: 
- https://jdk.java.net/11/

- https://github.com/docker-library/openjdk/issues/211#issuecomment-426641655